### PR TITLE
Calendar | 달력 화면 진입 시 마이페이지/다른 사용자 프로필 구분 추가

### DIFF
--- a/app/src/main/java/com/applemango/runnerbe/presentation/screen/fragment/mypage/MyPageFragment.kt
+++ b/app/src/main/java/com/applemango/runnerbe/presentation/screen/fragment/mypage/MyPageFragment.kt
@@ -307,7 +307,8 @@ class MyPageFragment : ImageBaseFragment<FragmentMypageBinding>(R.layout.fragmen
             }
 
             binding.ivCalendar -> {
-                navigate(MainFragmentDirections.actionMainFragmentToMonthlyCalendarFragment())
+                val userId = RunnerBeApplication.mTokenPreference.getUserId()
+                navigate(MainFragmentDirections.actionMainFragmentToMonthlyCalendarFragment(userId, 0))
             }
 
             binding.settingButton -> {

--- a/app/src/main/java/com/applemango/runnerbe/presentation/screen/fragment/mypage/calendar/MonthlyCalendarViewModel.kt
+++ b/app/src/main/java/com/applemango/runnerbe/presentation/screen/fragment/mypage/calendar/MonthlyCalendarViewModel.kt
@@ -11,6 +11,8 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOn
 import java.time.LocalDate
@@ -22,6 +24,9 @@ class MonthlyCalendarViewModel @Inject constructor(
 ): ViewModel() {
     val stampStatistic = MutableStateFlow(mapOf(Pair("크루", 4), Pair("개인", 6)))
 
+    private val _targetUserId = MutableStateFlow<Int?>(null)
+    val targetUserId: StateFlow<Int?> = _targetUserId.asStateFlow()
+
     private val _selectedYearMonth = MutableStateFlow(Pair(LocalDate.now().year, LocalDate.now().monthValue))
     val selectedYearMonth: StateFlow<Pair<Int, Int>> = _selectedYearMonth.asStateFlow()
 
@@ -32,13 +37,22 @@ class MonthlyCalendarViewModel @Inject constructor(
     @ExperimentalCoroutinesApi
     val selectedYearMonthFlow: Flow<CommonResponse> = selectedYearMonth
         .flatMapLatest { yearMonthPair ->
-            val userId = RunnerBeApplication.mTokenPreference.getUserId()
-            getMonthlyRunningLogListUseCase(userId, yearMonthPair.first, yearMonthPair.second)
+            try {
+                val userId = requireNotNull(_targetUserId.value)
+                getMonthlyRunningLogListUseCase(userId, yearMonthPair.first, yearMonthPair.second)
+            } catch (e: IllegalArgumentException) {
+                e.printStackTrace()
+                emptyFlow()
+            }
         }.flowOn(Dispatchers.IO)
 
     fun updateSelectedYearMonth(year: Int, month: Int) {
         if (year != _selectedYearMonth.value.first || month != _selectedYearMonth.value.second) {
             _selectedYearMonth.value = Pair(year, month)
         }
+    }
+
+    fun updateTargetUserId(userId: Int) {
+        _targetUserId.value = userId
     }
 }

--- a/app/src/main/java/com/applemango/runnerbe/presentation/screen/fragment/mypage/calendar/MonthlyDateViewHolder.kt
+++ b/app/src/main/java/com/applemango/runnerbe/presentation/screen/fragment/mypage/calendar/MonthlyDateViewHolder.kt
@@ -39,10 +39,10 @@ class MonthlyOtherUserDateViewHolder (
                     }
                 }
             }
-            item.runningLog?.let {
-                ivStamp.setImageResource(getStampItemByCode(it.stampCode).image)
+            item.runningLog?.let { log ->
+                ivStamp.setImageResource(getStampItemByCode(log.stampCode).image)
                 llDate.setOnClickListener {
-                    when (item.runningLog?.gatheringId) {
+                    when (log.gatheringId) {
                         null -> {
                             onDateClickListener.onDateClicked(item)
                         }

--- a/app/src/main/java/com/applemango/runnerbe/presentation/screen/fragment/mypage/runninglog/UserProfileFragment.kt
+++ b/app/src/main/java/com/applemango/runnerbe/presentation/screen/fragment/mypage/runninglog/UserProfileFragment.kt
@@ -20,9 +20,11 @@ import com.applemango.runnerbe.presentation.screen.fragment.mypage.calendar.init
 import com.applemango.runnerbe.util.ToastUtil
 import com.applemango.runnerbe.util.dpToPx
 import com.applemango.runnerbe.util.recyclerview.RightSpaceItemDecoration
+import com.jakewharton.rxbinding4.view.clicks
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
+import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 
 @AndroidEntryPoint
@@ -42,6 +44,7 @@ class UserProfileFragment : BaseFragment<FragmentUserProfileBinding>(R.layout.fr
         initJoinedRunningPostRecyclerView()
         initWeeklyCalendarAdapter()
         setupUserData()
+        initDisposables()
     }
 
     private fun setupUserData() {
@@ -71,6 +74,25 @@ class UserProfileFragment : BaseFragment<FragmentUserProfileBinding>(R.layout.fr
             joinedRunningPostAdapter.submitList(list)
         }
     }
+
+    private fun initDisposables() {
+        compositeDisposable.addAll(
+            getCalendarClickDisposable()
+        )
+    }
+
+    private fun getCalendarClickDisposable() = binding.ivCalendar.clicks()
+        .throttleFirst(1000L, TimeUnit.MILLISECONDS)
+        .subscribe {
+            viewModel.targetUserIdFlow.value?.let { userId ->
+                navigate(
+                    UserProfileFragmentDirections.actionUserProfileFragmentToMonthlyCalendarFragment(
+                        userId,
+                        1
+                    )
+                )
+            }
+        }
 
     private fun initWeeklyCalendarAdapter() {
         binding.rcvCalendarWeekly.apply {

--- a/app/src/main/java/com/applemango/runnerbe/presentation/screen/fragment/mypage/runninglog/UserProfileViewModel.kt
+++ b/app/src/main/java/com/applemango/runnerbe/presentation/screen/fragment/mypage/runninglog/UserProfileViewModel.kt
@@ -24,7 +24,8 @@ import javax.inject.Inject
 class UserProfileViewModel @Inject constructor(
     private val getOtherUserProfileUseCase: GetOtherUserProfileUseCase
 ): ViewModel() {
-    private val targetUserIdFlow = MutableStateFlow<Int?>(null)
+    private val _targetUserIdFlow = MutableStateFlow<Int?>(null)
+    val targetUserIdFlow : StateFlow<Int?> get() = _targetUserIdFlow.asStateFlow()
 
     private val date = LocalDate.now()
     val today: String = "${date.year}년 ${date.monthValue}월"
@@ -39,7 +40,7 @@ class UserProfileViewModel @Inject constructor(
     val userPostings: StateFlow<List<Posting>> = _userPostings.asStateFlow()
 
     @OptIn(ExperimentalCoroutinesApi::class)
-    val otherUserProfileFlow: Flow<String> = targetUserIdFlow
+    val otherUserProfileFlow: Flow<String> = _targetUserIdFlow
         .filterNotNull()
         .flatMapLatest { id ->
             getOtherUserProfileUseCase(id)
@@ -63,6 +64,6 @@ class UserProfileViewModel @Inject constructor(
         }
 
     fun updateTargetUserId(targetUserId: Int) {
-        targetUserIdFlow.value = targetUserId
+        _targetUserIdFlow.value = targetUserId
     }
 }

--- a/app/src/main/res/layout/fragment_user_profile.xml
+++ b/app/src/main/res/layout/fragment_user_profile.xml
@@ -321,22 +321,6 @@
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toBottomOf="@id/tv_week" />
 
-                <TextView
-                    android:id="@+id/tv_stamp_weekly"
-                    android:layout_width="0dp"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="12dp"
-                    android:background="@drawable/bg_dark_6g_solid_radius_6"
-                    android:fontFamily="@font/pretendard_medium"
-                    android:gravity="center"
-                    android:paddingVertical="10dp"
-                    android:text="@string/lets_add_stamp"
-                    android:textColor="@color/dark_g3_5"
-                    android:textSize="15sp"
-                    app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toBottomOf="@+id/rcv_calendar_weekly" />
-
             </androidx.constraintlayout.widget.ConstraintLayout>
 
             <androidx.constraintlayout.widget.ConstraintLayout

--- a/app/src/main/res/layout/item_date_monthly.xml
+++ b/app/src/main/res/layout/item_date_monthly.xml
@@ -20,8 +20,9 @@
 
         <ImageView
             android:id="@+id/iv_stamp"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
+            android:layout_width="30dp"
+            android:layout_height="30dp"
+            android:scaleType="fitXY"
             android:layout_marginTop="2dp"
             tools:src="@drawable/ic_stamp_unavailable" />
 

--- a/app/src/main/res/layout/item_date_weekly.xml
+++ b/app/src/main/res/layout/item_date_weekly.xml
@@ -29,8 +29,9 @@
 
         <ImageView
             android:id="@+id/iv_stamp"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
+            android:layout_width="30dp"
+            android:layout_height="30dp"
+            android:scaleType="fitXY"
             android:layout_marginTop="10dp"
             tools:src="@drawable/ic_stamp_unavailable" />
 

--- a/app/src/main/res/navigation/nav_main.xml
+++ b/app/src/main/res/navigation/nav_main.xml
@@ -301,6 +301,15 @@
         android:name="com.applemango.runnerbe.presentation.screen.fragment.mypage.calendar.MonthlyCalendarFragment"
         android:label="fragment_monthly_calendar"
         tools:layout="@layout/fragment_monthly_calendar" >
+
+        <argument
+            android:name="userId"
+            app:argType="integer" />
+
+        <argument
+            android:name="isOtherUser"
+            app:argType="integer" />
+
         <action
             android:id="@+id/action_monthlyCalendarFragment_to_runningLogFragment"
             app:destination="@id/runningLogFragment"
@@ -356,6 +365,13 @@
         <action
             android:id="@+id/action_userProfileFragment_to_postDetailFragment"
             app:destination="@id/postDetailFragment"
+            app:enterAnim="@anim/from_right"
+            app:exitAnim="@anim/to_left"
+            app:popEnterAnim="@anim/from_left"
+            app:popExitAnim="@anim/to_right" />
+        <action
+            android:id="@+id/action_userProfileFragment_to_monthlyCalendarFragment"
+            app:destination="@id/monthlyCalendarFragment"
             app:enterAnim="@anim/from_right"
             app:exitAnim="@anim/to_left"
             app:popEnterAnim="@anim/from_left"


### PR DESCRIPTION
1. 다른 사용자 월간 로그 조회 시에도 기존 월간 캘린더 화면을 사용
2. 다른 사용자 프로필에서 진입 시 로그 작성 가능(개인) 스탬프 이미지를 "다른 사용자 프로필 용 이미지"로 변경