### PR TITLE
참여한 러닝 이동 로직 및 구조 변경

### DIFF
--- a/app/src/main/java/com/applemango/runnerbe/presentation/screen/dialog/stamp/StampBottomSheetDialog.kt
+++ b/app/src/main/java/com/applemango/runnerbe/presentation/screen/dialog/stamp/StampBottomSheetDialog.kt
@@ -5,13 +5,10 @@ import android.view.View
 import androidx.fragment.app.FragmentManager
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.LinearSmoothScroller
-import androidx.recyclerview.widget.LinearSnapHelper
-import androidx.recyclerview.widget.RecyclerView
 import androidx.recyclerview.widget.RecyclerView.SmoothScroller
 import com.applemango.runnerbe.R
 import com.applemango.runnerbe.databinding.DialogBottomSheetStampBinding
 import com.applemango.runnerbe.presentation.screen.dialog.CustomBottomSheetDialog
-import com.applemango.runnerbe.util.LogUtil
 import com.applemango.runnerbe.util.dpToPx
 import com.applemango.runnerbe.util.recyclerview.LeftSpaceItemDecoration
 
@@ -34,9 +31,7 @@ class StampBottomSheetDialog(
     }
 
     init {
-        this.selectedStamp = selectedStamp.also {
-            LogUtil.debugLog(it.toString())
-        }
+        this.selectedStamp = selectedStamp
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {

--- a/app/src/main/java/com/applemango/runnerbe/presentation/screen/fragment/bookmark/BookMarkFragment.kt
+++ b/app/src/main/java/com/applemango/runnerbe/presentation/screen/fragment/bookmark/BookMarkFragment.kt
@@ -10,7 +10,6 @@ import com.applemango.runnerbe.R
 import com.applemango.runnerbe.data.dto.Posting
 import com.applemango.runnerbe.databinding.FragmentBookMarkBinding
 import com.applemango.runnerbe.presentation.model.RunningTag
-import com.applemango.runnerbe.presentation.model.listener.BookMarkClickListener
 import com.applemango.runnerbe.presentation.screen.deco.RecyclerViewItemDeco
 import com.applemango.runnerbe.presentation.screen.fragment.base.BaseFragment
 import com.applemango.runnerbe.presentation.screen.fragment.main.MainViewModel
@@ -58,9 +57,7 @@ class BookMarkFragment : BaseFragment<FragmentBookMarkBinding>(R.layout.fragment
                     }
 
                     override fun bookMarkClick(post: Posting) {
-                        // 북마크 화면에서 해당 아이템 제거
-                        // 게시글 화면에서 해당 아이템 북마크 상태 변경
-                        mainViewModel.bookmarkStatusChange(BookmarkChangedFrom.BOOKMARK, post)
+                        mainViewModel.bookmarkStatusChange(post)
                         viewModel.addOrRemoveBookmarkedPost(post)
                     }
 
@@ -95,18 +92,8 @@ class BookMarkFragment : BaseFragment<FragmentBookMarkBinding>(R.layout.fragment
                 }
 
                 launch {
-                    // 게시글 화면에서 북마크 상태 변경된 아이템 collect
-                    mainViewModel.bookmarkPost.collect { changedEvent ->
-                        viewModel.addOrRemoveBookmarkedPost(changedEvent.posting)
-//                        when (changedEvent.changedFrom) {
-//                            BookmarkChangedFrom.BOOKMARK -> {
-//                                viewModel.addOrRemoveBookmarkedPost(changedEvent.posting)
-//                            }
-//
-//                            BookmarkChangedFrom.RUNNINGPOST -> {
-//                                viewModel.updatePostBookmark(changedEvent.posting)
-//                            }
-//                        }
+                    mainViewModel.bookmarkPost.collect { posting ->
+                        viewModel.addOrRemoveBookmarkedPost(posting)
                     }
                 }
             }

--- a/app/src/main/java/com/applemango/runnerbe/presentation/screen/fragment/main/MainViewModel.kt
+++ b/app/src/main/java/com/applemango/runnerbe/presentation/screen/fragment/main/MainViewModel.kt
@@ -7,19 +7,12 @@ import com.applemango.runnerbe.RunnerBeApplication
 import com.applemango.runnerbe.data.dto.Posting
 import com.applemango.runnerbe.data.network.response.BaseResponse
 import com.applemango.runnerbe.domain.usecase.bookmark.BookMarkStatusChangeUseCase
-import com.applemango.runnerbe.presentation.screen.fragment.bookmark.BookmarkChangedFrom
-import com.applemango.runnerbe.presentation.screen.fragment.mypage.joinedrunning.JoinedRunningClickListener
 import com.applemango.runnerbe.presentation.state.CommonResponse
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.launch
 import javax.inject.Inject
-
-data class BookmarkChangedEvent (
-    val changedFrom: BookmarkChangedFrom,
-    val posting: Posting
-)
 
 @HiltViewModel
 class MainViewModel @Inject constructor(
@@ -29,7 +22,7 @@ class MainViewModel @Inject constructor(
     val currentItem: MutableSharedFlow<Int> = MutableSharedFlow()
     val clickedPost: MutableStateFlow<Posting?> = MutableStateFlow(null)
 
-    private val _bookmarkPost : MutableSharedFlow<BookmarkChangedEvent> = MutableSharedFlow()
+    private val _bookmarkPost : MutableSharedFlow<Posting> = MutableSharedFlow()
     val bookmarkPost get() = _bookmarkPost
 
     private var _isShowInfoDialog: MutableSharedFlow<Boolean> = MutableSharedFlow()
@@ -43,7 +36,7 @@ class MainViewModel @Inject constructor(
         clickedPost.value = posting
     }
 
-    fun bookmarkStatusChange(changedFrom: BookmarkChangedFrom, post: Posting) = viewModelScope.launch {
+    fun bookmarkStatusChange(post: Posting) = viewModelScope.launch {
         val userId = RunnerBeApplication.mTokenPreference.getUserId()
         if (userId > 0) {
             bookMarkStatusChangeUseCase(
@@ -54,12 +47,7 @@ class MainViewModel @Inject constructor(
                 when(it) {
                     is CommonResponse.Success<*> -> {
                         if(it.body is BaseResponse && it.body.isSuccess) {
-                            _bookmarkPost.emit(
-                                BookmarkChangedEvent(
-                                    changedFrom,
-                                    post
-                                )
-                            )
+                            _bookmarkPost.emit(post)
                         }
                     }
                     else -> {

--- a/app/src/main/java/com/applemango/runnerbe/presentation/screen/fragment/map/RunnerMapFragment.kt
+++ b/app/src/main/java/com/applemango/runnerbe/presentation/screen/fragment/map/RunnerMapFragment.kt
@@ -4,9 +4,7 @@ import android.os.Bundle
 import android.util.Log
 import android.view.View
 import androidx.fragment.app.viewModels
-import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
-import androidx.lifecycle.repeatOnLifecycle
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.applemango.runnerbe.R
 import com.applemango.runnerbe.RunnerBeApplication
@@ -17,7 +15,6 @@ import com.applemango.runnerbe.presentation.model.PostIncomingType
 import com.applemango.runnerbe.presentation.screen.deco.RecyclerViewItemDeco
 import com.applemango.runnerbe.presentation.screen.dialog.selectitem.SelectItemDialog
 import com.applemango.runnerbe.presentation.screen.fragment.base.BaseFragment
-import com.applemango.runnerbe.presentation.screen.fragment.bookmark.BookmarkChangedFrom
 import com.applemango.runnerbe.presentation.screen.fragment.main.MainFragmentDirections
 import com.applemango.runnerbe.presentation.screen.fragment.main.MainViewModel
 import com.applemango.runnerbe.presentation.screen.fragment.mypage.joinedrunning.JoinedRunningClickListener
@@ -84,8 +81,8 @@ class RunnerMapFragment : BaseFragment<FragmentRunnerMapBinding>(R.layout.fragme
     private fun observeBind() {
         viewLifecycleOwner.lifecycleScope.launch {
             launch {
-                mainViewModel.bookmarkPost.collect { changedEvent ->
-                    postAdapter.updatePostBookmark(changedEvent.posting)
+                mainViewModel.bookmarkPost.collect { posting ->
+                    postAdapter.updatePostBookmark(posting)
                 }
             }
             launch {
@@ -177,7 +174,7 @@ class RunnerMapFragment : BaseFragment<FragmentRunnerMapBinding>(R.layout.fragme
                     }
 
                     override fun bookMarkClick(post: Posting) {
-                        mainViewModel.bookmarkStatusChange(BookmarkChangedFrom.RUNNINGPOST, post) // 북마크 화면에 추가/제거할 아이템 설정
+                        mainViewModel.bookmarkStatusChange(post) // 북마크 화면에 추가/제거할 아이템 설정
                         viewModel.updatePostBookmark(post) // 게시글 화면에 해당 아이템 북마크 상태 변경
                     }
 

--- a/app/src/main/java/com/applemango/runnerbe/presentation/screen/fragment/mypage/MyPageFragment.kt
+++ b/app/src/main/java/com/applemango/runnerbe/presentation/screen/fragment/mypage/MyPageFragment.kt
@@ -17,16 +17,17 @@ import com.applemango.runnerbe.R
 import com.applemango.runnerbe.RunnerBeApplication
 import com.applemango.runnerbe.data.dto.Posting
 import com.applemango.runnerbe.databinding.FragmentMypageBinding
+import com.applemango.runnerbe.presentation.model.PostIncomingType
 import com.applemango.runnerbe.presentation.screen.dialog.message.MessageDialog
 import com.applemango.runnerbe.presentation.screen.dialog.selectitem.SelectItemDialog
 import com.applemango.runnerbe.presentation.screen.dialog.selectitem.SelectItemParameter
 import com.applemango.runnerbe.presentation.screen.fragment.base.ImageBaseFragment
 import com.applemango.runnerbe.presentation.screen.fragment.main.MainFragmentDirections
 import com.applemango.runnerbe.presentation.screen.fragment.main.MainViewModel
+import com.applemango.runnerbe.presentation.screen.fragment.mypage.calendar.WeeklyCalendarPagerAdapter
 import com.applemango.runnerbe.presentation.screen.fragment.mypage.joinedrunning.JoinedRunningClickListener
 import com.applemango.runnerbe.presentation.screen.fragment.mypage.joinedrunning.JoinedRunningPostAdapter
 import com.applemango.runnerbe.presentation.state.UiState
-import com.applemango.runnerbe.util.LogUtil
 import com.applemango.runnerbe.util.dpToPx
 import com.applemango.runnerbe.util.recyclerview.RightSpaceItemDecoration
 import com.applemango.runnerbe.util.toUri
@@ -201,7 +202,6 @@ class MyPageFragment : ImageBaseFragment<FragmentMypageBinding>(R.layout.fragmen
         viewLifecycleOwner.lifecycleScope.launch {
             repeatOnLifecycle(Lifecycle.State.STARTED) {
                 viewModel.currentWeeklyViewPagerPosition.collectLatest { position ->
-                    LogUtil.errorLog("CurrentViewPager position: $position")
                     position?.let {
                         binding.vpWeeklyCalendar.setCurrentItem(position, false)
                     }
@@ -252,31 +252,33 @@ class MyPageFragment : ImageBaseFragment<FragmentMypageBinding>(R.layout.fragmen
 
     private fun initParticipatedRunningAdapter() {
         with(binding.rcvJoinedRunningPost) {
-            adapter = joinedRunningPostAdapter
-            joinedRunningPostAdapter.setPostClickListener(object : JoinedRunningClickListener {
-                override fun logWriteClick(post: Posting) {
+            adapter = joinedRunningPostAdapter.apply {
+                setPostClickListener(object : JoinedRunningClickListener {
+                    override fun logWriteClick(post: Posting) {
 
-                }
+                    }
 
-                override fun attendanceSeeClick(post: Posting) {
+                    override fun attendanceSeeClick(post: Posting) {
 
-                }
+                    }
 
-                override fun attendanceManageClick(post: Posting) {
+                    override fun attendanceManageClick(post: Posting) {
 
-                }
+                    }
 
-                override fun bookMarkClick(post: Posting) {
+                    override fun bookMarkClick(post: Posting) {
 
-                }
+                    }
 
-                override fun postClick(post: Posting) {
-                    navigate(
-                        MainFragmentDirections.actionMainFragmentToPostDetailFragment(post)
-                    )
-                }
+                    override fun postClick(post: Posting) {
+                        navigate(
+                            MainFragmentDirections.actionMainFragmentToPostDetailFragment(post)
+                        )
+                    }
+                })
 
-            })
+                setIncomingType(PostIncomingType.HOME)
+            }
             layoutManager = LinearLayoutManager(context, LinearLayoutManager.HORIZONTAL, false)
             addItemDecoration(RightSpaceItemDecoration(12.dpToPx(context)))
         }

--- a/app/src/main/java/com/applemango/runnerbe/presentation/screen/fragment/mypage/calendar/WeeklyCalendarFragment.kt
+++ b/app/src/main/java/com/applemango/runnerbe/presentation/screen/fragment/mypage/calendar/WeeklyCalendarFragment.kt
@@ -1,4 +1,4 @@
-package com.applemango.runnerbe.presentation.screen.fragment.mypage
+package com.applemango.runnerbe.presentation.screen.fragment.mypage.calendar
 
 import android.os.Bundle
 import android.view.View
@@ -13,9 +13,7 @@ import com.applemango.runnerbe.data.network.response.RunningLog
 import com.applemango.runnerbe.databinding.FragmentWeeklyCalendarBinding
 import com.applemango.runnerbe.presentation.screen.fragment.base.BaseFragment
 import com.applemango.runnerbe.presentation.screen.fragment.main.MainFragmentDirections
-import com.applemango.runnerbe.presentation.screen.fragment.mypage.calendar.WeeklyCalendarAdapter
-import com.applemango.runnerbe.presentation.screen.fragment.mypage.calendar.initWeekDays
-import com.applemango.runnerbe.util.parseLocalDateToKorean
+import com.applemango.runnerbe.presentation.screen.fragment.mypage.MyPageViewModel
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch

--- a/app/src/main/java/com/applemango/runnerbe/presentation/screen/fragment/mypage/calendar/WeeklyCalendarPagerAdapter.kt
+++ b/app/src/main/java/com/applemango/runnerbe/presentation/screen/fragment/mypage/calendar/WeeklyCalendarPagerAdapter.kt
@@ -1,4 +1,4 @@
-package com.applemango.runnerbe.presentation.screen.fragment.mypage
+package com.applemango.runnerbe.presentation.screen.fragment.mypage.calendar
 
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentManager

--- a/app/src/main/java/com/applemango/runnerbe/presentation/screen/fragment/mypage/joinedrunning/JoinedRunningCategory.kt
+++ b/app/src/main/java/com/applemango/runnerbe/presentation/screen/fragment/mypage/joinedrunning/JoinedRunningCategory.kt
@@ -1,0 +1,6 @@
+package com.applemango.runnerbe.presentation.screen.fragment.mypage.joinedrunning
+
+enum class JoinedRunningCategory {
+    ALL,
+    MY
+}

--- a/app/src/main/java/com/applemango/runnerbe/presentation/screen/fragment/mypage/joinedrunning/JoinedRunningClickListener.kt
+++ b/app/src/main/java/com/applemango/runnerbe/presentation/screen/fragment/mypage/joinedrunning/JoinedRunningClickListener.kt
@@ -1,0 +1,12 @@
+package com.applemango.runnerbe.presentation.screen.fragment.mypage.joinedrunning
+
+import com.applemango.runnerbe.data.dto.Posting
+
+interface JoinedRunningClickListener {
+
+    fun logWriteClick(post: Posting)
+    fun attendanceSeeClick(post: Posting)
+    fun attendanceManageClick(post: Posting)
+    fun bookMarkClick(post: Posting)
+    fun postClick(post: Posting)
+}

--- a/app/src/main/java/com/applemango/runnerbe/presentation/screen/fragment/mypage/joinedrunning/JoinedRunningFragment.kt
+++ b/app/src/main/java/com/applemango/runnerbe/presentation/screen/fragment/mypage/joinedrunning/JoinedRunningFragment.kt
@@ -86,11 +86,9 @@ class JoinedRunningFragment : BaseFragment<FragmentJoinedRunningBinding>(R.layou
 
                     override fun attendanceSeeClick(post: Posting) {
                         try {
-                            val userId = requireNotNull(post.userId)
                             navigate(
                                 JoinedRunningFragmentDirections.actionJoinedRunningFragmentToMyPostAttendanceSeeFragment(
-                                    post.postId,
-                                    userId
+                                    post.runnerList?.toTypedArray() ?: arrayOf()
                                 )
                             )
                         } catch (e: IllegalArgumentException) {
@@ -101,11 +99,9 @@ class JoinedRunningFragment : BaseFragment<FragmentJoinedRunningBinding>(R.layou
 
                     override fun attendanceManageClick(post: Posting) {
                         try {
-                            val userId = requireNotNull(post.userId)
                             navigate(
                                 JoinedRunningFragmentDirections.actionJoinedRunningFragmentToMyPostAttendanceAccessionFragment(
-                                    post.postId,
-                                    userId
+                                    post.runnerList?.toTypedArray() ?: arrayOf()
                                 )
                             )
                         } catch (e: IllegalArgumentException) {

--- a/app/src/main/java/com/applemango/runnerbe/presentation/screen/fragment/mypage/joinedrunning/JoinedRunningFragment.kt
+++ b/app/src/main/java/com/applemango/runnerbe/presentation/screen/fragment/mypage/joinedrunning/JoinedRunningFragment.kt
@@ -1,0 +1,131 @@
+package com.applemango.runnerbe.presentation.screen.fragment.mypage.joinedrunning
+
+import android.os.Bundle
+import android.view.View
+import androidx.fragment.app.viewModels
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
+import androidx.recyclerview.widget.LinearLayoutManager
+import com.applemango.runnerbe.R
+import com.applemango.runnerbe.RunnerBeApplication
+import com.applemango.runnerbe.data.dto.Posting
+import com.applemango.runnerbe.databinding.FragmentJoinedRunningBinding
+import com.applemango.runnerbe.presentation.model.PostIncomingType
+import com.applemango.runnerbe.presentation.screen.fragment.base.BaseFragment
+import com.applemango.runnerbe.util.ToastUtil
+import com.applemango.runnerbe.util.dpToPx
+import com.applemango.runnerbe.util.recyclerview.BottomSpaceItemDecoration
+import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@AndroidEntryPoint
+class JoinedRunningFragment : BaseFragment<FragmentJoinedRunningBinding>(R.layout.fragment_joined_running) {
+
+    private val viewModel: JoinedRunningViewModel by viewModels()
+
+    @Inject
+    internal lateinit var joinedRunningPostAdapter: JoinedRunningPostAdapter
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        binding.vm = viewModel
+        initCategoryRadioGroup()
+        initRunningRecyclerView()
+        setupRunningLogsFlow()
+        getUserPostings()
+    }
+
+    private fun getUserPostings() {
+        val userId = RunnerBeApplication.mTokenPreference.getUserId()
+        viewModel.getUserRunningPostings(userId)
+    }
+
+    private fun setupRunningLogsFlow() {
+        viewLifecycleOwner.lifecycleScope.launch {
+            repeatOnLifecycle(Lifecycle.State.STARTED) {
+                viewModel.userPostingFlow.collectLatest { postings ->
+                    joinedRunningPostAdapter.submitList(postings)
+                }
+            }
+        }
+    }
+
+    private fun initCategoryRadioGroup() {
+        binding.rgCategory.apply {
+            setOnCheckedChangeListener { _, checkedId ->
+                when (checkedId) {
+                    R.id.rb_all -> viewModel.updateSelectedCategory(JoinedRunningCategory.ALL)
+                    R.id.rb_my -> viewModel.updateSelectedCategory(JoinedRunningCategory.MY)
+                }
+            }
+        }
+    }
+
+    private fun initRunningRecyclerView() {
+        binding.rcvPosting.apply {
+            adapter = joinedRunningPostAdapter.apply {
+                setIncomingType(PostIncomingType.PROFILE)
+                setPostClickListener(object: JoinedRunningClickListener {
+                    override fun logWriteClick(post: Posting) {
+                        try {
+                            navigate(
+                                JoinedRunningFragmentDirections.actionJoinedRunningFragmentToRunningLogFragment(
+                                    post.gatheringTime?.toLocalDate().toString(),
+                                    null,
+                                    null
+                                )
+                            )
+                        } catch (e: IllegalArgumentException) {
+                            e.printStackTrace()
+                            ToastUtil.showShortToast(context, "러닝 로그가 존재하지 않습니다.")
+                        }
+                    }
+
+                    override fun attendanceSeeClick(post: Posting) {
+                        try {
+                            val userId = requireNotNull(post.userId)
+                            navigate(
+                                JoinedRunningFragmentDirections.actionJoinedRunningFragmentToMyPostAttendanceSeeFragment(
+                                    post.postId,
+                                    userId
+                                )
+                            )
+                        } catch (e: IllegalArgumentException) {
+                            e.printStackTrace()
+                            ToastUtil.showShortToast(context, "참여한 러너가 없습니다.")
+                        }
+                    }
+
+                    override fun attendanceManageClick(post: Posting) {
+                        try {
+                            val userId = requireNotNull(post.userId)
+                            navigate(
+                                JoinedRunningFragmentDirections.actionJoinedRunningFragmentToMyPostAttendanceAccessionFragment(
+                                    post.postId,
+                                    userId
+                                )
+                            )
+                        } catch (e: IllegalArgumentException) {
+                            e.printStackTrace()
+                            ToastUtil.showShortToast(context, "참여한 러너가 없습니다.")
+                        }
+                    }
+
+                    override fun bookMarkClick(post: Posting) {
+
+                    }
+
+                    override fun postClick(post: Posting) {
+
+                    }
+
+                })
+            }
+            addItemDecoration(BottomSpaceItemDecoration(12.dpToPx(context)))
+            layoutManager = LinearLayoutManager(context, LinearLayoutManager.VERTICAL, false)
+        }
+    }
+}

--- a/app/src/main/java/com/applemango/runnerbe/presentation/screen/fragment/mypage/joinedrunning/JoinedRunningPostAdapter.kt
+++ b/app/src/main/java/com/applemango/runnerbe/presentation/screen/fragment/mypage/joinedrunning/JoinedRunningPostAdapter.kt
@@ -6,11 +6,13 @@ import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import com.applemango.runnerbe.data.dto.Posting
 import com.applemango.runnerbe.databinding.ItemJoinPostWithBookmarkBinding
+import com.applemango.runnerbe.presentation.model.PostIncomingType
 
 class JoinedRunningPostAdapter : ListAdapter<Posting, JoinedRunningPostViewHolder>(
     joinedRunningPostDiffUtil
 ) {
     private lateinit var listener: JoinedRunningClickListener
+    private lateinit var incomingType: PostIncomingType
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): JoinedRunningPostViewHolder {
         val inflater = LayoutInflater.from(parent.context)
@@ -20,12 +22,16 @@ class JoinedRunningPostAdapter : ListAdapter<Posting, JoinedRunningPostViewHolde
     override fun onBindViewHolder(holder: JoinedRunningPostViewHolder, position: Int) {
         val item = getItem(position)
         if (item != null) {
-            holder.bind(item, listener)
+            holder.bind(item, listener, incomingType)
         }
     }
 
     fun setPostClickListener(listener: JoinedRunningClickListener) {
         this.listener = listener
+    }
+
+    fun setIncomingType(incomingType: PostIncomingType) {
+        this.incomingType = incomingType
     }
 
     companion object {

--- a/app/src/main/java/com/applemango/runnerbe/presentation/screen/fragment/mypage/joinedrunning/JoinedRunningPostViewHolder.kt
+++ b/app/src/main/java/com/applemango/runnerbe/presentation/screen/fragment/mypage/joinedrunning/JoinedRunningPostViewHolder.kt
@@ -3,14 +3,14 @@ package com.applemango.runnerbe.presentation.screen.fragment.mypage.joinedrunnin
 import androidx.recyclerview.widget.RecyclerView
 import com.applemango.runnerbe.data.dto.Posting
 import com.applemango.runnerbe.databinding.ItemJoinPostWithBookmarkBinding
-import com.applemango.runnerbe.util.LogUtil
+import com.applemango.runnerbe.presentation.model.PostIncomingType
 
 class JoinedRunningPostViewHolder(
     private val binding: ItemJoinPostWithBookmarkBinding
 ): RecyclerView.ViewHolder(binding.root) {
-    fun bind(item: Posting, listener: JoinedRunningClickListener) {
-        LogUtil.errorLog(item.toString())
+    fun bind(item: Posting, listener: JoinedRunningClickListener, incomingType: PostIncomingType) {
         binding.item = item
         binding.clickListener = listener
+        binding.incomingType = incomingType
     }
 }

--- a/app/src/main/java/com/applemango/runnerbe/presentation/screen/fragment/mypage/joinedrunning/JoinedRunningViewModel.kt
+++ b/app/src/main/java/com/applemango/runnerbe/presentation/screen/fragment/mypage/joinedrunning/JoinedRunningViewModel.kt
@@ -1,0 +1,76 @@
+package com.applemango.runnerbe.presentation.screen.fragment.mypage.joinedrunning
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.applemango.runnerbe.RunnerBeApplication
+import com.applemango.runnerbe.data.dto.Posting
+import com.applemango.runnerbe.data.network.response.GetMyPageResult
+import com.applemango.runnerbe.data.network.response.UserDataResponse
+import com.applemango.runnerbe.domain.usecase.GetUserDataUseCase
+import com.applemango.runnerbe.presentation.state.CommonResponse
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+/**
+ * 추후 마이페이지 API 변경 시 동일하게 적용할 것
+ * @author 로키
+ */
+@HiltViewModel
+class JoinedRunningViewModel @Inject constructor(
+    private val getUserDataUseCase: GetUserDataUseCase
+) : ViewModel() {
+    private val selectedCategoryId: MutableStateFlow<JoinedRunningCategory> = MutableStateFlow(
+        JoinedRunningCategory.ALL
+    )
+    private val userPostings: MutableStateFlow<List<Posting>> = MutableStateFlow(emptyList())
+
+    val userPostingSize: MutableStateFlow<Int> = MutableStateFlow(0)
+
+    val userPostingFlow: Flow<List<Posting>> = combine(
+        userPostings,
+        selectedCategoryId
+    ) { postings, categoryId ->
+        when (categoryId) {
+            JoinedRunningCategory.ALL -> postings
+            JoinedRunningCategory.MY -> {
+                val userId = RunnerBeApplication.mTokenPreference.getUserId()
+                postings.filter {
+                    it.postUserId == userId
+                }
+            }
+        }.sortedByDescending {
+            it.gatheringTime
+        }.also {
+            userPostingSize.value = it.size
+        }
+    }
+
+    fun getUserRunningPostings(userId: Int) {
+        viewModelScope.launch {
+            getUserDataUseCase(userId)
+                .collectLatest { response ->
+                    when (response) {
+                        is CommonResponse.Success<*> -> {
+                            if (response.body is UserDataResponse) {
+                                val result = response.body.result as? GetMyPageResult
+                                userPostings.value = result?.posting ?: emptyList()
+                            }
+                        }
+
+                        else -> {
+                            throw Exception("")
+                        }
+                    }
+                }
+        }
+    }
+
+    fun updateSelectedCategory(category: JoinedRunningCategory) {
+        selectedCategoryId.value = category
+    }
+}

--- a/app/src/main/java/com/applemango/runnerbe/presentation/screen/fragment/mypage/mypost/accession/MyPostAttendanceAccessionFragment.kt
+++ b/app/src/main/java/com/applemango/runnerbe/presentation/screen/fragment/mypage/mypost/accession/MyPostAttendanceAccessionFragment.kt
@@ -24,7 +24,8 @@ class MyPostAttendanceAccessionFragment : BaseFragment<FragmentMyPostAttendanceA
         super.onViewCreated(view, savedInstanceState)
         binding.vm = viewModel
         viewModel.postId = args.postId
-        viewModel.userListUpdate(args.users.toList())
+        // TODO - 네비게이션 아규먼트 수정 후 usecase 호출해서 리스트 보여주기...
+//        viewModel.userListUpdate(args.users.toList())
         viewLifecycleOwner.lifecycleScope.launch {
             viewModel.submitState.collect {
                 context?.let { context ->

--- a/app/src/main/java/com/applemango/runnerbe/presentation/screen/fragment/mypage/mypost/accession/MyPostAttendanceAccessionFragment.kt
+++ b/app/src/main/java/com/applemango/runnerbe/presentation/screen/fragment/mypage/mypost/accession/MyPostAttendanceAccessionFragment.kt
@@ -23,9 +23,7 @@ class MyPostAttendanceAccessionFragment : BaseFragment<FragmentMyPostAttendanceA
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         binding.vm = viewModel
-        viewModel.postId = args.postId
-        // TODO - 네비게이션 아규먼트 수정 후 usecase 호출해서 리스트 보여주기...
-//        viewModel.userListUpdate(args.users.toList())
+        viewModel.userListUpdate(args.users.toList())
         viewLifecycleOwner.lifecycleScope.launch {
             viewModel.submitState.collect {
                 context?.let { context ->

--- a/app/src/main/java/com/applemango/runnerbe/presentation/screen/fragment/mypage/mypost/see/MyPostAttendanceSeeFragment.kt
+++ b/app/src/main/java/com/applemango/runnerbe/presentation/screen/fragment/mypage/mypost/see/MyPostAttendanceSeeFragment.kt
@@ -16,8 +16,7 @@ class MyPostAttendanceSeeFragment : BaseFragment<FragmentMyPostAttendanceSeeBind
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         binding.vm = viewModel
-        // TODO - 네비게이션 아규먼트 수정 후 usecase 호출해서 리스트 보여주기...
-//        viewModel.userListUpdate(args.users.toList())
+        viewModel.userListUpdate(args.users.toList())
         context?.let {
             binding.attendanceSeeRecyclerView.addItemDecoration(RecyclerViewItemDeco(it, 18))
         }

--- a/app/src/main/java/com/applemango/runnerbe/presentation/screen/fragment/mypage/mypost/see/MyPostAttendanceSeeFragment.kt
+++ b/app/src/main/java/com/applemango/runnerbe/presentation/screen/fragment/mypage/mypost/see/MyPostAttendanceSeeFragment.kt
@@ -16,7 +16,8 @@ class MyPostAttendanceSeeFragment : BaseFragment<FragmentMyPostAttendanceSeeBind
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         binding.vm = viewModel
-        viewModel.userListUpdate(args.users.toList())
+        // TODO - 네비게이션 아규먼트 수정 후 usecase 호출해서 리스트 보여주기...
+//        viewModel.userListUpdate(args.users.toList())
         context?.let {
             binding.attendanceSeeRecyclerView.addItemDecoration(RecyclerViewItemDeco(it, 18))
         }

--- a/app/src/main/java/com/applemango/runnerbe/util/LogUtil.kt
+++ b/app/src/main/java/com/applemango/runnerbe/util/LogUtil.kt
@@ -4,7 +4,7 @@ import android.util.Log
 
 object LogUtil {
     private fun getTag(): String {
-        return Thread.currentThread().stackTrace
+        return Exception().stackTrace
             .firstOrNull {
                 it.className != LogUtil::class.java.name
                         && !it.className.contains("java.lang.Thread")

--- a/app/src/main/res/layout/fragment_joined_running.xml
+++ b/app/src/main/res/layout/fragment_joined_running.xml
@@ -1,0 +1,133 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    xmlns:bind="http://schemas.android.com/tools"
+    tools:context=".presentation.screen.fragment.mypage.joinedrunning.JoinedRunningFragment">
+
+    <data>
+        <import type="android.view.View"/>
+        <import type="com.applemango.runnerbe.presentation.model.PostIncomingType"/>
+
+        <variable
+            name="incomingType"
+            type="com.applemango.runnerbe.presentation.model.PostIncomingType" />
+
+        <variable
+            name="vm"
+            type="com.applemango.runnerbe.presentation.screen.fragment.mypage.joinedrunning.JoinedRunningViewModel" />
+
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:background="@color/dark_g7">
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/const_top"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:paddingHorizontal="8dp"
+            app:layout_constraintTop_toTopOf="parent">
+
+            <androidx.appcompat.widget.AppCompatImageView
+                android:id="@+id/btn_back"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:clickable="true"
+                android:paddingHorizontal="10dp"
+                android:paddingVertical="15dp"
+                android:src="@drawable/ic_back"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintLeft_toLeftOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <androidx.appcompat.widget.AppCompatTextView
+                android:id="@+id/tv_date_time"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginVertical="5dp"
+                android:fontFamily="@font/pretendard_medium"
+                android:textColor="@color/dark_g3_5"
+                android:textSize="18sp"
+                android:text="@string/joined_post_title"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintLeft_toLeftOf="parent"
+                app:layout_constraintRight_toRightOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+        <RadioGroup
+            android:id="@+id/rg_category"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="12dp"
+            android:layout_marginTop="19dp"
+            android:background="@drawable/bg_tab"
+            android:orientation="horizontal"
+            android:checkedButton="@id/rb_all"
+            app:layout_constraintTop_toBottomOf="@id/const_top"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent">
+
+            <RadioButton
+                android:id="@+id/rb_all"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_margin="4dp"
+                android:layout_weight="1"
+                android:background="@drawable/selector_tab"
+                android:button="@null"
+                android:checked="true"
+                android:gravity="center"
+                android:paddingVertical="12dp"
+                android:text="@string/joined_post_category_all"
+                android:textColor="@color/tc_select_tab"
+                android:textSize="14sp" />
+
+            <RadioButton
+                android:id="@+id/rb_my"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_margin="4dp"
+                android:layout_weight="1"
+                android:background="@drawable/selector_tab"
+                android:button="@null"
+                android:checked="false"
+                android:gravity="center"
+                android:paddingVertical="12dp"
+                android:text="@string/joined_post_category_my"
+                android:textColor="@color/tc_select_tab"
+                android:textSize="14sp" />
+
+        </RadioGroup>
+
+        <androidx.appcompat.widget.AppCompatTextView
+            android:id="@+id/tv_posting_size"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginVertical="16dp"
+            android:layout_marginStart="12dp"
+            android:textColor="@color/dark_g4"
+            android:textSize="18sp"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/rg_category"
+            android:text="@{`총 ` + vm.userPostingSize + `건`}" />
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/rcv_posting"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:overScrollMode="never"
+            android:layout_marginTop="20dp"
+            android:layout_marginHorizontal="12dp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/tv_posting_size" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+</layout>

--- a/app/src/main/res/layout/fragment_weekly_calendar.xml
+++ b/app/src/main/res/layout/fragment_weekly_calendar.xml
@@ -2,7 +2,7 @@
 <layout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
-    tools:context=".presentation.screen.fragment.mypage.WeeklyCalendarFragment">
+    tools:context=".presentation.screen.fragment.mypage.calendar.WeeklyCalendarFragment">
 
     <FrameLayout
         android:layout_width="match_parent"

--- a/app/src/main/res/layout/item_join_post_with_bookmark.xml
+++ b/app/src/main/res/layout/item_join_post_with_bookmark.xml
@@ -212,7 +212,7 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:gravity="center"
-                    bind:isVisible="@{item.whetherEnded}"
+                    bind:isVisible="@{!item.whetherEnded}"
                     android:text="@string/before_running_management_button_text"
                     android:textSize="14sp"
                     android:textColor="@color/dark_g4"

--- a/app/src/main/res/navigation/nav_main.xml
+++ b/app/src/main/res/navigation/nav_main.xml
@@ -166,12 +166,8 @@
         android:label="MyPostAttendanceSeeFragment" >
 
         <argument
-            android:name="postId"
-            app:argType="integer"/>
-
-        <argument
-            android:name="userId"
-            app:argType="integer"/>
+            android:name="users"
+            app:argType="com.applemango.runnerbe.data.dto.UserInfo[]" />
     </fragment>
     <fragment
         android:id="@+id/myPostAttendanceAccessionFragment"
@@ -180,12 +176,8 @@
         android:label="MyPostAttendanceAccessionFragment">
 
         <argument
-            android:name="postId"
-            app:argType="integer"/>
-
-        <argument
-            android:name="userId"
-            app:argType="integer"/>
+            android:name="users"
+            app:argType="com.applemango.runnerbe.data.dto.UserInfo[]" />
 
     </fragment>
     <fragment

--- a/app/src/main/res/navigation/nav_main.xml
+++ b/app/src/main/res/navigation/nav_main.xml
@@ -27,12 +27,6 @@
             android:id="@+id/action_mainFragment_to_runningFilterFragment"
             app:destination="@id/runningFilterFragment" />
         <action
-            android:id="@+id/action_mainFragment_to_myPostAttendanceSeeFragment"
-            app:destination="@id/myPostAttendanceSeeFragment" />
-        <action
-            android:id="@+id/action_mainFragment_to_myPostAttendanceAccessionFragment"
-            app:destination="@id/myPostAttendanceAccessionFragment" />
-        <action
             android:id="@+id/action_mainFragment_to_runningTalkDetailFragment"
             app:destination="@id/runningTalkDetailFragment" />
         <action
@@ -172,8 +166,12 @@
         android:label="MyPostAttendanceSeeFragment" >
 
         <argument
-            android:name="users"
-            app:argType="com.applemango.runnerbe.data.dto.UserInfo[]"/>
+            android:name="postId"
+            app:argType="integer"/>
+
+        <argument
+            android:name="userId"
+            app:argType="integer"/>
     </fragment>
     <fragment
         android:id="@+id/myPostAttendanceAccessionFragment"
@@ -186,8 +184,8 @@
             app:argType="integer"/>
 
         <argument
-            android:name="users"
-            app:argType="com.applemango.runnerbe.data.dto.UserInfo[]"/>
+            android:name="userId"
+            app:argType="integer"/>
 
     </fragment>
     <fragment
@@ -410,5 +408,15 @@
     <fragment
         android:id="@+id/joinedRunningFragment"
         android:name="com.applemango.runnerbe.presentation.screen.fragment.mypage.joinedrunning.JoinedRunningFragment"
-        android:label="JoinedRunningFragment" />
+        android:label="JoinedRunningFragment" >
+        <action
+            android:id="@+id/action_joinedRunningFragment_to_myPostAttendanceSeeFragment"
+            app:destination="@id/myPostAttendanceSeeFragment" />
+        <action
+            android:id="@+id/action_joinedRunningFragment_to_myPostAttendanceAccessionFragment"
+            app:destination="@id/myPostAttendanceAccessionFragment" />
+        <action
+            android:id="@+id/action_joinedRunningFragment_to_runningLogFragment"
+            app:destination="@id/runningLogFragment" />
+    </fragment>
 </navigation>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -342,6 +342,8 @@
     <string name="sunday">일</string>
 
     <!-- 참여한 러닝/내가 만든 모임-->
-    <string name="joined_post_nickname">%s님 참여한 러닝</string>
+    <string name="joined_post_title">참여한 러닝</string>
+    <string name="joined_post_category_all">전체</string>
+    <string name="joined_post_category_my">내가 만든 모임</string>
 
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <style name="base_font">
+        <item name="fontFamily">@font/pretendard_regular</item>
+    </style>
 
     <style name="tab_text" parent="TextAppearance.Design.Tab">
         <item name="android:textSize">16dp</item>
@@ -15,5 +18,9 @@
 
     <style name="photo_round_shape_14">
         <item name="cornerSize">14dp</item>
+    </style>
+
+    <style name="tab_item_selected" parent="base_font">
+        <item name="android:textStyle">bold</item>
     </style>
 </resources>


### PR DESCRIPTION
[참여한 러닝]
기존 : 마이페이지에서 별도 페이지 전환 없이 출석 관리/출석 확인 페이지로 이동
신규 : 마이페이지->참여한러닝에서 리사이클러뷰의 아이템 클릭 시 해당 아이템의 상태에 따라 클릭 불가/출석 관리/출석 확인 페이지로 이동