### PR TITLE
지도 바텀 시트 기능 개선

### DIFF
--- a/app/src/main/res/drawable/bg_top_rectangle.xml
+++ b/app/src/main/res/drawable/bg_top_rectangle.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+  <item>
+    <shape android:shape="rectangle">
+      <solid android:color="@color/black" />
+    </shape>
+  </item>
+</selector>

--- a/app/src/main/res/layout/fragment_runner_map.xml
+++ b/app/src/main/res/layout/fragment_runner_map.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto">
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
 
     <data>
         <import type="android.view.View"/>
@@ -29,12 +30,14 @@
                 android:id="@+id/top_txt"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
-                android:fontFamily="sans-serif-black"
+                android:fontFamily="@font/pretendard_medium"
                 android:gravity="center_horizontal"
                 android:text="address"
                 android:textColor="@color/dark_g3_5"
-                android:textSize="18dp"
+                android:textSize="18sp"
+                android:textStyle="bold"
                 android:paddingVertical="10dp"
+                tools:text="서울시 동작구"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
@@ -45,7 +48,6 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:padding="10dp"
-                android:visibility="gone"
                 android:src="@drawable/ic_bell"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintEnd_toEndOf="parent"
@@ -65,28 +67,24 @@
             app:umanoOverlay="true"
             app:umanoPanelHeight="74dp"
             app:umanoShadowHeight="0dp"
+            app:umanoAnchorPoint="0.5"
+            app:umanoInitialState="anchored"
             app:layout_constraintTop_toBottomOf="@id/mapTopLayout"
             app:layout_constraintBottom_toBottomOf="parent">
 
-            <FrameLayout
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:id="@+id/mapLayout"
                 android:layout_width="match_parent"
-                android:layout_height="match_parent">
+                android:layout_height="match_parent"
+                android:orientation="vertical">
 
-                <androidx.constraintlayout.widget.ConstraintLayout
-                    android:id="@+id/mapLayout"
+                <com.naver.maps.map.MapView
+                    android:id="@+id/map_view"
                     android:layout_width="match_parent"
-                    android:layout_height="match_parent"
-                    android:orientation="vertical">
+                    android:layout_height="wrap_content"
+                    app:layout_constraintTop_toTopOf="parent"/>
 
-                    <!-- 네이버 지도 -->
-                    <com.naver.maps.map.MapView
-                        android:id="@+id/map_view"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        app:layout_constraintTop_toTopOf="parent"/>
-
-                </androidx.constraintlayout.widget.ConstraintLayout>
-            </FrameLayout>
+            </androidx.constraintlayout.widget.ConstraintLayout>
 
             <androidx.appcompat.widget.LinearLayoutCompat
                 android:id="@+id/bottomDrawerLayout"
@@ -113,11 +111,11 @@
                         android:id="@+id/slidingTabTextView"
                         android:layout_width="match_parent"
                         android:layout_height="50dp"
-                        android:layout_marginLeft="16dp"
+                        android:layout_marginStart="16dp"
                         android:layout_marginTop="16dp"
                         android:text="@string/running_list"
-                        android:textColor="@color/dark_g2_5"
-                        android:textSize="16dp"
+                        android:textColor="@color/dark_g3_5"
+                        android:textSize="16sp"
                         android:textStyle="bold" />
 
                 </androidx.appcompat.widget.LinearLayoutCompat>
@@ -138,18 +136,17 @@
             android:layout_height="wrap_content"
             android:paddingHorizontal="14dp"
             android:paddingVertical="8dp"
-            android:layout_marginTop="12dp"
+            android:layout_marginEnd="12dp"
             android:gravity="center"
             android:visibility="@{vm.refreshThisLocation ? View.VISIBLE : View.GONE}"
             android:background="@drawable/bg_dark_g7_solid_radius_20"
-            app:layout_constraintLeft_toLeftOf="parent"
-            app:layout_constraintRight_toRightOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintTop_toBottomOf="@id/mapTopLayout">
 
             <androidx.appcompat.widget.AppCompatImageView
                 android:layout_width="20dp"
                 android:layout_height="20dp"
-                android:layout_marginRight="4dp"
+                android:layout_marginEnd="4dp"
                 android:src="@drawable/ic_refresh"/>
 
             <androidx.appcompat.widget.AppCompatTextView
@@ -158,7 +155,6 @@
                 android:text="@string/refresh_this_location"
                 android:textSize="14sp"
                 android:textColor="@color/dark_g3"/>
-
         </androidx.appcompat.widget.LinearLayoutCompat>
 
         <androidx.appcompat.widget.AppCompatImageView

--- a/app/src/main/res/layout/inlcude_running_post_list.xml
+++ b/app/src/main/res/layout/inlcude_running_post_list.xml
@@ -57,7 +57,7 @@
                     <androidx.appcompat.widget.AppCompatTextView
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:layout_marginLeft="7dp"
+                        android:layout_marginStart="6dp"
                         android:fontFamily="@font/pretendard_bold"
                         android:includeFontPadding="false"
                         android:text="@string/filter"
@@ -70,7 +70,7 @@
                     android:id="@+id/priorityButton"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:layout_marginLeft="7dp"
+                    android:layout_marginStart="8dp"
                     android:background="@drawable/bg_dark_5_5g_solid_radius_14"
                     android:gravity="center"
                     android:onClick="@{() -> vm.priorityTagClicked()}"
@@ -102,7 +102,7 @@
                     android:id="@+id/runningTagButton"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:layout_marginLeft="7dp"
+                    android:layout_marginStart="8dp"
                     android:background="@drawable/bg_dark_5_5g_solid_radius_14"
                     android:gravity="center"
                     android:onClick="@{() -> vm.runningTagClicked()}"
@@ -133,7 +133,7 @@
                 <CheckBox
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:layout_marginLeft="7dp"
+                    android:layout_marginStart="8dp"
                     android:background="@drawable/selector_filter"
                     android:button="@null"
                     android:checked="@={vm.includeFinish}"
@@ -160,9 +160,9 @@
                 android:paddingHorizontal="12dp"
                 android:paddingTop="20dp"
                 android:paddingBottom="16dp"
+                android:overScrollMode="never"
                 android:visibility="@{vm.postList.empty ? View.GONE : View.VISIBLE}"
                 app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
-                app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintLeft_toLeftOf="parent"
                 app:layout_constraintRight_toRightOf="parent"
                 app:layout_constraintTop_toBottomOf="@id/filterLayout" />
@@ -170,7 +170,7 @@
             <androidx.appcompat.widget.AppCompatTextView
                 android:id="@+id/emptyTextView"
                 android:layout_width="0dp"
-                android:layout_height="wrap_content"
+                android:layout_height="0dp"
                 android:gravity="center"
                 android:paddingVertical="83dp"
                 android:text="@string/empty_post"
@@ -179,6 +179,7 @@
                 android:visibility="@{vm.postList.empty ? View.VISIBLE : View.GONE}"
                 app:layout_constraintLeft_toLeftOf="parent"
                 app:layout_constraintRight_toRightOf="parent"
+                app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintTop_toBottomOf="@id/filterLayout" />
 
         </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
[지도]
1. 바텀 시트 최대 확장 시 '이 지역 재검색'버튼 숨김 처리
2. 바텀 시트 최대 확장 시 바텀 시트 상단 Radius 제거
3. 필터 항목들 마진 값 통일
4. 알림 버튼 추가
5. 상단 주소 텍스트 크기/볼드 적용
6. '러닝 목록' 텍스트 색상 G3.5로 변경