### PR TITLE
러닝톡 UI 개선 및 오류 수정

### DIFF
--- a/app/src/main/java/com/applemango/runnerbe/presentation/screen/fragment/chat/detail/RunningTalkDetailFragment.kt
+++ b/app/src/main/java/com/applemango/runnerbe/presentation/screen/fragment/chat/detail/RunningTalkDetailFragment.kt
@@ -202,7 +202,7 @@ class RunningTalkDetailFragment :
                         }
 
                         else -> {
-                            Log.e(this.javaClass.name, "observeBind - when - else - UiState")
+                            Log.e(this.javaClass.name, "observeBind - when - else - UiState | $it")
                         }
                     }
                 }

--- a/app/src/main/java/com/applemango/runnerbe/presentation/screen/fragment/chat/detail/RunningTalkDetailFragment.kt
+++ b/app/src/main/java/com/applemango/runnerbe/presentation/screen/fragment/chat/detail/RunningTalkDetailFragment.kt
@@ -72,6 +72,15 @@ class RunningTalkDetailFragment :
         binding.topMessageLayout.setOnClickListener { hideKeyBoard() }
         setupTalkDetail()
         setupTalkAttachedImages()
+        setupTalkUpdate()
+    }
+
+    private fun setupTalkUpdate() {
+        viewLifecycleOwner.lifecycleScope.launch {
+            repeatOnLifecycle(Lifecycle.State.STARTED) {
+                refresh()
+            }
+        }
     }
 
     private fun setupTalkDetail() {
@@ -214,11 +223,7 @@ class RunningTalkDetailFragment :
     }
 
     private fun refresh() {
-        viewLifecycleOwner.lifecycleScope.launch {
-            repeatOnLifecycle(Lifecycle.State.STARTED) {
-                viewModel.getDetailData(true)
-            }
-        }
+        viewModel.getDetailData(true)
     }
 
     private fun handleAction(action: RunningTalkDetailAction) {

--- a/app/src/main/java/com/applemango/runnerbe/presentation/screen/fragment/chat/detail/RunningTalkDetailOtherContainerViewHolder.kt
+++ b/app/src/main/java/com/applemango/runnerbe/presentation/screen/fragment/chat/detail/RunningTalkDetailOtherContainerViewHolder.kt
@@ -14,7 +14,6 @@ import com.applemango.runnerbe.databinding.ItemOtherTalkContainerBinding
 import com.applemango.runnerbe.presentation.screen.fragment.chat.RunningTalkDetailClickListener
 import com.applemango.runnerbe.presentation.screen.fragment.chat.detail.uistate.RunningTalkItem
 import com.applemango.runnerbe.presentation.screen.fragment.chat.detail.uistate.RunningTalkUiState
-import com.applemango.runnerbe.util.LogUtil
 import com.applemango.runnerbe.util.dpToPx
 import com.applemango.runnerbe.util.glide.GranularRoundedAndBorderTransform
 import com.bumptech.glide.Glide
@@ -63,7 +62,6 @@ class RunningTalkDetailOtherContainerViewHolder(
                             null
                         )
                         if (item.items.last() == it) {
-                            LogUtil.errorLog("AAA createDateView ${item.createTime}")
                             createDateView.text = item.createTime
                             createDateView.visibility = View.VISIBLE
                         } else {

--- a/app/src/main/java/com/applemango/runnerbe/presentation/screen/fragment/chat/detail/RunningTalkDetailViewModel.kt
+++ b/app/src/main/java/com/applemango/runnerbe/presentation/screen/fragment/chat/detail/RunningTalkDetailViewModel.kt
@@ -16,7 +16,6 @@ import com.applemango.runnerbe.domain.entity.Pace
 import com.applemango.runnerbe.domain.usecase.runningtalk.GetRunningTalkDetailUseCase
 import com.applemango.runnerbe.domain.usecase.runningtalk.MessageReportUseCase
 import com.applemango.runnerbe.domain.usecase.runningtalk.MessageSendUseCase
-import com.applemango.runnerbe.presentation.screen.fragment.chat.detail.image.preview.RunningTalkDetailImageSelectListener
 import com.applemango.runnerbe.presentation.screen.fragment.chat.detail.mapper.RunningTalkDetailMapper
 import com.applemango.runnerbe.presentation.screen.fragment.chat.detail.uistate.RunningTalkUiState
 import com.applemango.runnerbe.presentation.state.CommonResponse
@@ -61,14 +60,16 @@ class RunningTalkDetailViewModel @Inject constructor(
     private val successImageList = ArrayList<String>()
     private val maxImageCount = 3
 
-    fun getDetailData(isRefresh: Boolean) = viewModelScope.launch {
-        roomId?.let { roomId ->
-            runningTalkDetailUseCase(roomId).collect {
-                if (it is CommonResponse.Success<*> && it.body is RunningTalkDetailResponse) {
-                    if (isRefresh) messageList.clear()
-                    roomInfo.emit(it.body.result.roomInfo[0])
-                    messageList.addAll(it.body.result.messages)
-                    talkList.value = RunningTalkDetailMapper.messagesToRunningTalkUiState(it.body.result.messages)
+    fun getDetailData(isRefresh: Boolean) {
+        viewModelScope.launch {
+            roomId?.let { roomId ->
+                runningTalkDetailUseCase(roomId).collect {
+                    if (it is CommonResponse.Success<*> && it.body is RunningTalkDetailResponse) {
+                        if (isRefresh) messageList.clear()
+                        roomInfo.emit(it.body.result.roomInfo[0])
+                        messageList.addAll(it.body.result.messages)
+                        talkList.value = RunningTalkDetailMapper.messagesToRunningTalkUiState(it.body.result.messages)
+                    }
                 }
             }
         }

--- a/app/src/main/java/com/applemango/runnerbe/presentation/screen/fragment/chat/detail/RunningTalkDetailViewModel.kt
+++ b/app/src/main/java/com/applemango/runnerbe/presentation/screen/fragment/chat/detail/RunningTalkDetailViewModel.kt
@@ -68,7 +68,7 @@ class RunningTalkDetailViewModel @Inject constructor(
                         if (isRefresh) messageList.clear()
                         roomInfo.emit(it.body.result.roomInfo[0])
                         messageList.addAll(it.body.result.messages)
-                        talkList.value = RunningTalkDetailMapper.messagesToRunningTalkUiState(it.body.result.messages)
+                        talkList.value = RunningTalkDetailMapper.parseMessagesToRunningTalkUiState(it.body.result.messages)
                     }
                 }
             }

--- a/app/src/main/java/com/applemango/runnerbe/presentation/screen/fragment/map/RunnerMapFragment.kt
+++ b/app/src/main/java/com/applemango/runnerbe/presentation/screen/fragment/map/RunnerMapFragment.kt
@@ -200,11 +200,6 @@ class RunnerMapFragment : BaseFragment<FragmentRunnerMapBinding>(R.layout.fragme
         binding.mapView.onLowMemory()
     }
 
-    override fun onDestroy() {
-        binding.mapView.onDestroy()
-        super.onDestroy()
-    }
-
     private fun updatePanelViewsPosition(panelState: PanelState, slideOffset: Float) {
         val bottomDrawerTop = when (panelState) {
             PanelState.EXPANDED -> binding.bottomDrawerLayout.top
@@ -393,7 +388,6 @@ class RunnerMapFragment : BaseFragment<FragmentRunnerMapBinding>(R.layout.fragme
     }
 
     private fun moveToCurrentLocation(panelState: PanelState) {
-        LogUtil.errorLog(panelState.toString())
         val location = locationSource.lastLocation
         if (location != null) {
             val currentLatLng = LatLng(location.latitude, location.longitude)

--- a/app/src/main/res/layout/fragment_running_talk_detail.xml
+++ b/app/src/main/res/layout/fragment_running_talk_detail.xml
@@ -46,7 +46,7 @@
 
                 <TextView
                     android:id="@+id/top_txt"
-                    android:layout_width="0dp"
+                    android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:fontFamily="sans-serif-black"
                     android:gravity="center_horizontal"
@@ -54,8 +54,8 @@
                     android:textColor="@color/dark_g3_5"
                     android:textSize="18sp"
                     android:layout_marginHorizontal="10dp"
-                    app:layout_constraintStart_toEndOf="@id/iv_back"
-                    app:layout_constraintEnd_toStartOf="@id/tv_report"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintBottom_toBottomOf="parent"
                     app:layout_constraintTop_toTopOf="parent" />
 
@@ -130,8 +130,9 @@
                 android:layout_width="match_parent"
                 android:layout_height="0dp"
                 android:paddingHorizontal="16dp"
-                android:paddingVertical="20dp"
+                android:paddingTop="20dp"
                 android:overScrollMode="never"
+                android:clipToPadding="false"
                 app:layout_constraintBottom_toTopOf="@id/rcv_attached_image"
                 app:layout_constraintTop_toBottomOf="@id/titleLayout" />
 

--- a/app/src/main/res/layout/item_me_message_talk.xml
+++ b/app/src/main/res/layout/item_me_message_talk.xml
@@ -14,13 +14,13 @@
         tools:text="3/31"
         android:layout_gravity="bottom"
         android:fontFamily="@font/pretendard_regular"
-        android:textSize="11sp"
-        android:layout_marginEnd="4dp"/>
+        android:textSize="11sp"/>
 
     <androidx.appcompat.widget.AppCompatTextView
         android:id="@+id/message_view"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:layout_marginStart="8dp"
         android:paddingVertical="8dp"
         android:paddingHorizontal="10dp"
         tools:text="여기에 텍스트가 들어갈 예정입니다."

--- a/app/src/main/res/layout/item_other_message_talk.xml
+++ b/app/src/main/res/layout/item_other_message_talk.xml
@@ -22,12 +22,12 @@
 
     <androidx.appcompat.widget.AppCompatTextView
         android:id="@+id/create_date_view"
-        android:layout_width="24dp"
+        android:layout_width="wrap_content"
         android:layout_height="13dp"
         android:layout_gravity="bottom"
         android:fontFamily="@font/pretendard_regular"
         android:textSize="11sp"
-        android:layout_marginStart="4dp"
+        android:layout_marginStart="8dp"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintRight_toRightOf="parent"
         app:layout_constraintLeft_toRightOf="@id/message_view"


### PR DESCRIPTION
[RunningTalk]
1. 상단바 제목 텍스트 위치 가운데로 조정
2. 메시지 <-> 시간 텍스트 간격 증가
3. 메시지 파싱 로직 최적화, 메시지 전송 시각으로 선 그룹화된 후 내가 보낸/상대방이 보낸 메시지인지 판별하는 로직 오류로 인해 간헐적으로 내가/상대방이 보낸 메시지가 잘못된 진영에 보여지는 현상 수정