### PR TITLE
마이페이지 주간캘린더 기능 개선 및 참여한 러닝 오류 수정

### DIFF
--- a/app/src/main/java/com/applemango/runnerbe/data/network/response/MonthlyStampResponse.kt
+++ b/app/src/main/java/com/applemango/runnerbe/data/network/response/MonthlyStampResponse.kt
@@ -3,7 +3,6 @@ package com.applemango.runnerbe.data.network.response
 import com.google.gson.annotations.SerializedName
 import java.time.ZonedDateTime
 
-// TODO
 data class MonthlyStampResponse(
     val result: RunningLogResult
 ) : BaseResponse()

--- a/app/src/main/java/com/applemango/runnerbe/domain/usecase/runninglog/GetMonthlyRunningLogListUseCase.kt
+++ b/app/src/main/java/com/applemango/runnerbe/domain/usecase/runninglog/GetMonthlyRunningLogListUseCase.kt
@@ -10,7 +10,7 @@ import javax.inject.Inject
 class GetMonthlyRunningLogListUseCase @Inject constructor(
     private val runningLogRepository: RunningLogRepository
 ) {
-    operator fun invoke(userId: Int, year: Int, month: Int): Flow<CommonResponse> = flow {
+    suspend operator fun invoke(userId: Int, year: Int, month: Int): Flow<CommonResponse> = flow {
         kotlin.runCatching {
             runningLogRepository.getMonthlyRunningLogList(userId, year, month)
         }.onSuccess {

--- a/app/src/main/java/com/applemango/runnerbe/presentation/screen/fragment/mypage/MyPageFragment.kt
+++ b/app/src/main/java/com/applemango/runnerbe/presentation/screen/fragment/mypage/MyPageFragment.kt
@@ -75,6 +75,7 @@ class MyPageFragment : ImageBaseFragment<FragmentMypageBinding>(R.layout.fragmen
         initParticipatedRunningAdapter()
         initYearMonthSpinner()
         initListeners()
+        initWeeklyViewPagerAdapter()
         setupJoinedRunningPosts()
         setupThisWeekRunningLogs()
         setupWeeklyViewPagerPosition()
@@ -240,8 +241,8 @@ class MyPageFragment : ImageBaseFragment<FragmentMypageBinding>(R.layout.fragmen
     private fun setupThisWeekRunningLogs() {
         viewLifecycleOwner.lifecycleScope.launch {
             repeatOnLifecycle(Lifecycle.State.STARTED) {
-                viewModel.myPageInfo.collectLatest {
-                    initWeeklyViewPagerAdapter()
+                viewModel.runningLogResult.collectLatest {
+
                 }
             }
         }

--- a/app/src/main/java/com/applemango/runnerbe/presentation/screen/fragment/mypage/joinedrunning/JoinedRunningPostViewHolder.kt
+++ b/app/src/main/java/com/applemango/runnerbe/presentation/screen/fragment/mypage/joinedrunning/JoinedRunningPostViewHolder.kt
@@ -33,10 +33,10 @@ class JoinedRunningPostViewHolder(
                 false
             }
 
-            val firstButtonVisibility = !isRunningEnd
             val secondButtonVisibility =
                 isRunningEnd && !isThreeHourAfterRunningEnd && item.isRunningCaptain()
             val thirdButtonVisibility = isRunningEnd && isThreeHourAfterRunningEnd
+            val firstButtonVisibility = !(secondButtonVisibility || thirdButtonVisibility)
 
             runningEndTextViewVisibility = firstButtonVisibility
             attendanceCheckButtonVisibility = secondButtonVisibility

--- a/app/src/main/res/layout/fragment_mypage.xml
+++ b/app/src/main/res/layout/fragment_mypage.xml
@@ -327,6 +327,7 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:fontFamily="@font/pretendard_regular"
+                    android:text="@{myPageViewModel.currentMondayYearMonth}"
                     android:textColor="@color/dark_g3_5"
                     android:textSize="17sp"
                     android:textStyle="bold"


### PR DESCRIPTION
[Mypage]
1. 주간 캘린더에 두 달에 걸친 데이터가 보여져야 하는 경우(ex: 11월 + 12월의 데이터가 보여야하는 상황)
- 총 21개의 러닝 로그 데이터가 보여져야 하므로
- 현재는 오늘 날짜가 21일 미만이라면 병렬적으로 "저번달 & 이번달" 데이터를 조회한 후, Month 값을 키로 가지는 Map으로 변환하여 사용하고 있음
- _하지만 추후에는 Mypage 관련 API에서 오늘포함 21일간의 데이터를 제공하도록 서버측에서 수정하겠다고 안내 받음(일정은 미정)_
2. 주간 캘린더 슬라이드 시, 상단 제목 텍스트에  "해당 주 월요일의 Month"가 보여지도록 수정
- 월요일이 2024년 11월 30일이라면 "2024년 11월"이
- 2024년 12월 2일이라면 "2024년 12월"이 보여지도록 수정

[JoinedRunning]
1. 출석 관리하기 버튼이 활성화되어야 하는 상황이나, "런닝 주최자"가 아닌 경우에는 대신 "모임이 종료되어야 확인이 가능해요"라는 버튼이  활성화되어야 함
- 따라서 "출석 관리하기" 버튼과 "출석 확인하기" 버튼이 모두 비활성화된 상황에서는 항상 "모임이 종료되어야 확인이 가능해요" 버튼이 보여지도록 수정