### PR TITLE
텍스트 입력 시 커스텀 커서 추가 및 닉네임 변경 입력 수 제한

### DIFF
--- a/app/src/main/java/com/applemango/runnerbe/presentation/screen/dialog/weather/WeatherBottomSheetDialog.kt
+++ b/app/src/main/java/com/applemango/runnerbe/presentation/screen/dialog/weather/WeatherBottomSheetDialog.kt
@@ -49,7 +49,7 @@ class WeatherBottomSheetDialog(
         initClickListeners()
         scrollToSelectedStamp(weatherLayoutManager, selectedWeather)
 
-        binding.etTemperature.setText(currentTemperature.replace("+", ""))
+        binding.tieDegree.setText(currentTemperature.replace("+", ""))
     }
 
     override fun onDestroyView() {
@@ -67,9 +67,9 @@ class WeatherBottomSheetDialog(
                             R.drawable.ic_weather_1_sunny,
                             requireContext().getString(R.string.weather_1_sunny)
                         ),
-                        etTemperature.text.toString())
+                        tieDegree.text.toString())
                 } else {
-                    onWeatherConfirmListener?.onConfirmClicked(selectedWeather, etTemperature.text.toString())
+                    onWeatherConfirmListener?.onConfirmClicked(selectedWeather, tieDegree.text.toString())
                 }
 
                 dismiss()

--- a/app/src/main/java/com/applemango/runnerbe/presentation/screen/fragment/chat/detail/RunningTalkDetailFragment.kt
+++ b/app/src/main/java/com/applemango/runnerbe/presentation/screen/fragment/chat/detail/RunningTalkDetailFragment.kt
@@ -82,7 +82,7 @@ class RunningTalkDetailFragment :
             binding.ivSend.clicks()
                 .throttleFirst(1000L, TimeUnit.MILLISECONDS)
                 .subscribe {
-                    val message = binding.etMessage.text.toString()
+                    val message = binding.tieMessage.text.toString()
                     viewModel.sendMessage(message)
                 }
         )
@@ -179,7 +179,7 @@ class RunningTalkDetailFragment :
                         }
                         when (it) {
                             is UiState.Success -> {
-                                binding.etMessage.setText("")
+                                binding.tieMessage.setText("")
                                 refresh()
                             }
                             else -> { Log.e(this.javaClass.name, "observeBind - when - else - UiState") }

--- a/app/src/main/java/com/applemango/runnerbe/presentation/screen/fragment/mypage/editprofile/EditProfileFragment.kt
+++ b/app/src/main/java/com/applemango/runnerbe/presentation/screen/fragment/mypage/editprofile/EditProfileFragment.kt
@@ -146,7 +146,7 @@ class EditProfileFragment :
 
     private fun initListeners() {
         compositeDisposable.addAll(
-            binding.etNickname.textChanges()
+            binding.tieNickname.textChanges()
                 .filter { it.length <= 8 }
                 .subscribe {
                     binding.nameFailTxt.isVisible =
@@ -164,7 +164,7 @@ class EditProfileFragment :
                             secondButtonText = resources.getString(R.string.yes),
                             firstEvent = {},
                             secondEvent = {
-                                val name = binding.etNickname.text.toString()
+                                val name = binding.tieNickname.text.toString()
                                 if (name != viewModel.userInfo.value?.nickName) {
                                     viewModel.nicknameChange(name)
                                 }

--- a/app/src/main/java/com/applemango/runnerbe/presentation/screen/fragment/mypage/runninglog/write/RunningLogFragment.kt
+++ b/app/src/main/java/com/applemango/runnerbe/presentation/screen/fragment/mypage/runninglog/write/RunningLogFragment.kt
@@ -197,17 +197,17 @@ class RunningLogFragment : BaseFragment<FragmentRunningLogBinding>(R.layout.frag
                 constDiary.touches()
                     .throttleFirst(1000L, TimeUnit.MILLISECONDS)
                     .subscribe {
-                        etDiary.requestFocus()
+                        tieDiary.requestFocus()
                         val imm =
                             requireContext().getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
-                        imm.showSoftInput(etDiary, InputMethodManager.SHOW_IMPLICIT)
+                        imm.showSoftInput(tieDiary, InputMethodManager.SHOW_IMPLICIT)
                     },
                 constImage.clicks()
                     .throttleFirst(1000L, TimeUnit.MILLISECONDS)
                     .subscribe {
                         photoManager.showCameraDialog()
                     },
-                etDiary.textChanges()
+                tieDiary.textChanges()
                     .doOnNext { diary ->
                         if (diary.length == 500) {
                             context?.let {
@@ -221,7 +221,7 @@ class RunningLogFragment : BaseFragment<FragmentRunningLogBinding>(R.layout.frag
                         tvRunningDiaryCharCount.text =
                             getString(R.string.running_log_diary_length, diary.length)
                         scrollView.post {
-                            scrollView.smoothScrollTo(0, etDiary.bottom)
+                            scrollView.smoothScrollTo(0, tieDiary.bottom)
                         }
                     },
                 constTeam.clicks()
@@ -250,7 +250,7 @@ class RunningLogFragment : BaseFragment<FragmentRunningLogBinding>(R.layout.frag
                 btnSave.clicks()
                     .throttleFirst(1000L, TimeUnit.MILLISECONDS)
                     .subscribe {
-                        if (binding.etDiary.text.length >= 500) {
+                        if (binding.tieDiary.text.length >= 500) {
                             MessageDialog.createShow(
                                 context = requireContext(),
                                 message = getString(R.string.running_log_diary_max_length_alert),

--- a/app/src/main/java/com/applemango/runnerbe/util/ViewBindingAdapter.kt
+++ b/app/src/main/java/com/applemango/runnerbe/util/ViewBindingAdapter.kt
@@ -323,7 +323,7 @@ fun TextView.setStampText(stampItem: StampItem?) {
     if (stampItem == null) {
         this.text = context.getString(R.string.running_log_add_stamp)
     } else {
-        this.text = stampItem.description
+        this.text = stampItem.name
     }
 }
 
@@ -394,7 +394,7 @@ fun ImageView.setLogStampSrc(stampCode: String?) {
 fun TextView.setLogStampText(stampCode: String?) {
     if (stampCode == null) return
     val stamp = getStampItemByCode(stampCode)
-    this.text = stamp?.description ?: ""
+    this.text = stamp?.name ?: ""
 }
 
 @BindingAdapter("bind:logContentImageSrc")

--- a/app/src/main/res/layout/dialog_bottom_sheet_weather.xml
+++ b/app/src/main/res/layout/dialog_bottom_sheet_weather.xml
@@ -64,23 +64,42 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/rcv_weather" />
 
-        <EditText
-            android:id="@+id/et_temperature"
+        <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/til_degree"
+            style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginStart="24dp"
             android:layout_marginEnd="16dp"
             android:layout_marginTop="12dp"
-            android:padding="14dp"
+            android:paddingHorizontal="0dp"
+            android:paddingVertical="0dp"
             android:fontFamily="@font/pretendard_regular"
-            android:hint="@string/weather_temperature_hint"
-            android:textSize="16sp"
-            android:textColorHint="@color/dark_g3_5"
-            android:inputType="numberSigned"
+            app:counterEnabled="false"
+            app:endIconMode="clear_text"
+            app:endIconTint="@null"
+            app:endIconDrawable="@drawable/ic_search_clear"
+            app:hintEnabled="false"
             android:background="@drawable/bg_dark_5g_radius_8"
             app:layout_constraintTop_toBottomOf="@+id/tv_temperature_title"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toStartOf="@+id/tv_temperature_unit" />
+            app:layout_constraintEnd_toStartOf="@+id/tv_temperature_unit">
+
+            <EditText
+                android:id="@+id/tie_degree"
+                style="@style/TextStyleBody16"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:background="@color/transparent"
+                android:gravity="center_vertical"
+                android:hint="@string/weather_temperature_hint"
+                android:includeFontPadding="false"
+                android:textSize="16sp"
+                android:textColorHint="@color/dark_g3_5"
+                android:inputType="numberSigned"
+                android:paddingHorizontal="12dp"
+                android:textCursorDrawable="@drawable/cursor_primary" />
+        </com.google.android.material.textfield.TextInputLayout>
 
         <TextView
             android:id="@+id/tv_temperature_unit"
@@ -92,8 +111,8 @@
             android:text="@string/weather_temperature_unit"
             android:textColor="@color/dark_g2"
             android:textSize="17sp"
-            app:layout_constraintTop_toTopOf="@id/et_temperature"
-            app:layout_constraintBottom_toBottomOf="@id/et_temperature"
+            app:layout_constraintTop_toTopOf="@id/til_degree"
+            app:layout_constraintBottom_toBottomOf="@id/til_degree"
             app:layout_constraintEnd_toEndOf="parent" />
 
         <androidx.appcompat.widget.AppCompatTextView
@@ -111,7 +130,7 @@
             android:text="@string/stamp_apply"
             android:textColor="@color/tc_enable_dark3_5g_black"
             android:textSize="16sp"
-            app:layout_constraintTop_toBottomOf="@+id/et_temperature" />
+            app:layout_constraintTop_toBottomOf="@+id/til_degree" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/app/src/main/res/layout/fragment_edit_profile.xml
+++ b/app/src/main/res/layout/fragment_edit_profile.xml
@@ -75,24 +75,44 @@
             android:layout_height="wrap_content"
             app:layout_constraintTop_toBottomOf="@id/name_txt">
 
-            <EditText
-                android:id="@+id/user_name_edit"
-                style="@style/TextStyleBody14"
+            <com.google.android.material.textfield.TextInputLayout
+                android:id="@+id/til_nickname"
+                style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_marginStart="16dp"
                 android:layout_marginEnd="16dp"
                 android:layout_marginTop="16dp"
+                app:hintEnabled="false"
+                app:counterMaxLength="8"
                 android:background="@drawable/bg_dark_5g_radius_8"
                 android:enabled="@{(vm.userInfo.nameChanged.equals(String.valueOf('N')))}"
                 android:hint="@string/hint_nickname_change"
-                android:padding="16dp"
-                android:text="@={vm.name}"
-                android:textColor="@color/dark_g3_5"
-                android:textColorHint="@color/dark_g3_5"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintEnd_toStartOf="@id/name_change_btn"
-                app:layout_constraintTop_toTopOf="parent" />
+                app:layout_constraintTop_toTopOf="parent">
+
+                <com.google.android.material.textfield.TextInputEditText
+                    android:id="@+id/tie_nickname"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:background="@color/transparent"
+                    android:gravity="center_vertical"
+                    android:hint="@string/hint_nickname_change"
+                    android:includeFontPadding="false"
+                    android:inputType="text"
+                    android:text="@={vm.name}"
+                    android:textSize="14sp"
+                    android:textStyle="normal"
+                    android:textColor="@color/dark_g3_5"
+                    android:textColorHint="@color/dark_g3_5"
+                    android:textCursorDrawable="@drawable/cursor_primary"
+                    android:fontFamily="@font/pretendard_regular"
+                    android:maxLength="8"
+                    android:paddingHorizontal="12dp"
+                    android:paddingVertical="16dp" />
+
+            </com.google.android.material.textfield.TextInputLayout>
 
             <TextView
                 android:id="@+id/name_change_btn"
@@ -107,9 +127,9 @@
                 android:paddingHorizontal="16dp"
                 android:text="@{(vm.userInfo.nameChanged.equals(String.valueOf('N'))) ? @string/double_check : @string/finished_enrollment}"
                 android:textColor="@color/dark_g4_5"
-                app:layout_constraintBottom_toBottomOf="@id/user_name_edit"
+                app:layout_constraintBottom_toBottomOf="@id/til_nickname"
                 app:layout_constraintRight_toRightOf="parent"
-                app:layout_constraintTop_toTopOf="@id/user_name_edit"
+                app:layout_constraintTop_toTopOf="@id/til_nickname"
                 tools:text="중복확인" />
 
             <TextView
@@ -123,7 +143,7 @@
                 android:text="@{(vm.userInfo.nameChanged.equals(String.valueOf('N'))) ? @string/msg_possible_nickname_change : @string/msg_impossible_nickname_change}"
                 android:textColor="@color/logo_yellow"
                 app:layout_constraintLeft_toLeftOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/user_name_edit" />
+                app:layout_constraintTop_toBottomOf="@id/til_nickname" />
 
             <TextView
                 android:id="@+id/name_fail_txt"

--- a/app/src/main/res/layout/fragment_running_address_search.xml
+++ b/app/src/main/res/layout/fragment_running_address_search.xml
@@ -68,6 +68,7 @@
                 android:layout_width="24dp"
                 android:layout_height="24dp"
                 android:src="@drawable/ic_search"
+                android:textCursorDrawable="@drawable/cursor_primary"
                 app:layout_constraintTop_toTopOf="parent"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintStart_toStartOf="parent" />

--- a/app/src/main/res/layout/fragment_running_log.xml
+++ b/app/src/main/res/layout/fragment_running_log.xml
@@ -153,26 +153,45 @@
                     android:clickable="true"
                     android:minHeight="120dp"
                     android:paddingHorizontal="16dp"
-                    android:paddingVertical="12dp"
+                    android:paddingBottom="12dp"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toBottomOf="@+id/tv_running_diary_title">
 
-                    <EditText
-                        android:id="@+id/et_diary"
+                    <com.google.android.material.textfield.TextInputLayout
+                        android:id="@+id/til_diary"
+                        style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
                         android:layout_width="0dp"
                         android:layout_height="wrap_content"
-                        android:background="@color/transparent"
-                        android:fontFamily="@font/pretendard_regular"
-                        android:hint="@string/running_log_5_line_diary_hint"
-                        android:maxLength="500"
-                        android:text="@{vm.logDiary}"
-                        android:textColor="@color/dark_g3_5"
-                        android:textColorHint="@color/dark_g3_5"
-                        android:textSize="16sp"
+                        android:layout_marginStart="4dp"
+                        android:paddingHorizontal="0dp"
+                        android:paddingVertical="0dp"
+                        app:counterEnabled="false"
+                        app:hintEnabled="false"
                         app:layout_constraintEnd_toEndOf="parent"
                         app:layout_constraintStart_toStartOf="parent"
-                        app:layout_constraintTop_toTopOf="parent" />
+                        app:layout_constraintTop_toTopOf="parent">
+
+                        <EditText
+                            android:id="@+id/tie_diary"
+                            style="@style/TextStyleBody16"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:background="@color/transparent"
+                            android:gravity="center_vertical"
+                            android:fontFamily="@font/pretendard_regular"
+                            android:hint="@string/running_log_5_line_diary_hint"
+                            android:includeFontPadding="false"
+                            android:textColor="@color/dark_g3_5"
+                            android:textCursorDrawable="@drawable/cursor_primary"
+                            android:textSize="16sp"
+                            android:inputType="text"
+                            android:maxLength="500"
+                            android:text="@{vm.logDiary}"
+                            android:paddingStart="0dp"
+                            android:paddingEnd="0dp"
+                            android:textColorHint="@color/dark_g3_5" />
+                    </com.google.android.material.textfield.TextInputLayout>
 
                     <com.google.android.material.imageview.ShapeableImageView
                         android:id="@+id/iv_photo"
@@ -182,7 +201,7 @@
                         android:padding="1dp"
                         android:scaleType="fitXY"
                         app:layout_constraintStart_toStartOf="parent"
-                        app:layout_constraintTop_toBottomOf="@+id/et_diary"
+                        app:layout_constraintTop_toBottomOf="@+id/til_diary"
                         app:shapeAppearanceOverlay="@style/photo_round_shape_14"
                         bind:glideImageFromUri="@{vm.logImage}" />
 

--- a/app/src/main/res/layout/fragment_running_talk_detail.xml
+++ b/app/src/main/res/layout/fragment_running_talk_detail.xml
@@ -166,22 +166,40 @@
                     android:padding="14dp"
                     android:layout_gravity="center_vertical"/>
 
-                <androidx.appcompat.widget.AppCompatEditText
-                    android:id="@+id/et_message"
+                <com.google.android.material.textfield.TextInputLayout
+                    android:id="@+id/til_message"
+                    style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_weight="1"
                     android:maxLines="1"
-                    android:paddingTop="6dp"
-                    android:paddingBottom="8dp"
-                    android:paddingHorizontal="12dp"
-                    android:background="@drawable/bg_dark_5g_solid_radius_20"
-                    android:hint="내용을 입력하세요."
+                    app:counterEnabled="false"
+                    app:hintEnabled="false"
                     android:layout_gravity="center_vertical"
-                    android:text="@={vm.message}"
-                    android:textColorHint="@color/dark_g3_5"
-                    android:textColor="@color/dark_g1"
-                    android:textSize="14sp"/>
+                    android:background="@drawable/bg_dark_5g_solid_radius_20"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent">
+
+                    <EditText
+                        android:id="@+id/tie_message"
+                        style="@style/TextStyleBody16"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:background="@color/transparent"
+                        android:gravity="center_vertical"
+                        android:fontFamily="@font/pretendard_regular"
+                        android:hint="내용을 입력하세요."
+                        android:includeFontPadding="false"
+                        android:inputType="text"
+                        android:text="@={vm.message}"
+                        android:textCursorDrawable="@drawable/cursor_primary"
+                        android:textColor="@color/dark_g1"
+                        android:textSize="14sp"
+                        android:paddingHorizontal="12dp"
+                        android:paddingVertical="9dp"
+                        android:textColorHint="@color/dark_g3_5" />
+                </com.google.android.material.textfield.TextInputLayout>
 
                 <androidx.appcompat.widget.AppCompatImageView
                     android:id="@+id/iv_send"

--- a/app/src/main/res/layout/fragment_running_write.xml
+++ b/app/src/main/res/layout/fragment_running_write.xml
@@ -142,21 +142,45 @@
                     app:layout_constraintTop_toTopOf="parent"
                     app:layout_constraintLeft_toLeftOf="parent"/>
 
-                <androidx.appcompat.widget.AppCompatEditText
-                    android:id="@+id/titleEditText"
-                    android:layout_width="match_parent"
+                <com.google.android.material.textfield.TextInputLayout
+                    android:id="@+id/til_title"
+                    style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
+                    android:layout_width="0dp"
                     android:layout_height="wrap_content"
-                    android:layout_marginHorizontal="16dp"
+                    android:layout_marginEnd="16dp"
                     android:layout_marginTop="8dp"
-                    android:text="@={vm.runningTitle}"
-                    android:maxLength="30"
-                    android:hint="@string/hint_running_title"
+                    android:paddingHorizontal="0dp"
+                    android:paddingVertical="0dp"
+                    android:fontFamily="@font/pretendard_regular"
+                    app:counterEnabled="false"
+                    app:endIconMode="clear_text"
+                    app:endIconTint="@null"
+                    app:endIconDrawable="@drawable/ic_search_clear"
+                    app:hintEnabled="false"
                     android:background="@drawable/bg_dark_5_5g_radius_6"
-                    android:padding="16dp"
-                    android:textColor="@color/dark_g1"
-                    android:textColorHint="@color/dark_g3_5"
-                    android:textSize="14sp"
-                    app:layout_constraintTop_toBottomOf="@id/titleTextView"/>
+                    app:layout_constraintStart_toStartOf="@id/titleTextView"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/titleTextView">
+
+                    <EditText
+                        android:id="@+id/tie_title"
+                        style="@style/TextStyleBody16"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:background="@color/transparent"
+                        android:gravity="center_vertical"
+                        android:text="@={vm.runningTitle}"
+                        android:hint="@string/hint_running_title"
+                        android:includeFontPadding="false"
+                        android:maxLength="30"
+                        android:textColor="@color/dark_g1"
+                        android:textColorHint="@color/dark_g3_5"
+                        android:textSize="14sp"
+                        android:inputType="numberSigned"
+                        android:paddingHorizontal="12dp"
+                        android:paddingVertical="16dp"
+                        android:textCursorDrawable="@drawable/cursor_primary" />
+                </com.google.android.material.textfield.TextInputLayout>
 
                 <androidx.appcompat.widget.AppCompatTextView
                     android:id="@+id/dateTextView"
@@ -167,7 +191,7 @@
                     android:layout_marginLeft="16dp"
                     android:text="@string/date"
                     android:textColor="@color/dark_g3"
-                    app:layout_constraintTop_toBottomOf="@id/titleEditText"
+                    app:layout_constraintTop_toBottomOf="@id/til_title"
                     app:layout_constraintLeft_toLeftOf="parent"/>
 
                 <androidx.appcompat.widget.LinearLayoutCompat


### PR DESCRIPTION
[Mypage]
1. 사용자 닉네임 변경 시 최대 8자리만 입력 가능하도록 수정

[RunningLog]
1. 스탬프 선택 시, 설명이 아닌 이름이 표기되도록 수정

[Common]
1. 모든 EditText를 TextInputEditText로 변경 후 커스텀 커서 드로어블 적용