### PR TITLE
함께한 러너 리스트 어댑터 코드 정리

### DIFF
--- a/app/src/main/java/com/applemango/runnerbe/presentation/screen/fragment/mypage/runninglog/groupprofile/ProfileViewHolder.kt
+++ b/app/src/main/java/com/applemango/runnerbe/presentation/screen/fragment/mypage/runninglog/groupprofile/ProfileViewHolder.kt
@@ -1,0 +1,40 @@
+package com.applemango.runnerbe.presentation.screen.fragment.mypage.runninglog.groupprofile
+
+import android.view.View
+import androidx.recyclerview.widget.RecyclerView
+import com.applemango.runnerbe.R
+import com.applemango.runnerbe.data.network.response.JoinedRunnerResult
+import com.applemango.runnerbe.databinding.ItemGroupProfileBinding
+import com.applemango.runnerbe.presentation.screen.dialog.stamp.getStampItemByCode
+import com.applemango.runnerbe.presentation.screen.fragment.mypage.runninglog.otheruser.OtherUserProfileClickListener
+
+class ProfileViewHolder(
+    private val binding: ItemGroupProfileBinding,
+    private val updateSelectedPosition: (Int) -> Unit,
+) : RecyclerView.ViewHolder(binding.root) {
+    fun bind(
+        item: JoinedRunnerResult,
+        selectedPosition: Int,
+        otherUserProfileClickListener: OtherUserProfileClickListener?
+    ) {
+        val listener = View.OnClickListener {
+            otherUserProfileClickListener?.onProfileClicked(
+                bindingAdapterPosition,
+                item.userId,
+                getStampItemByCode(item.stampCode)
+            )
+            updateSelectedPosition(bindingAdapterPosition)
+        }
+
+        if (bindingAdapterPosition == selectedPosition) {
+            binding.flProfile.setBackgroundResource(R.drawable.bg_g5_circle_shape_primary_stroke)
+        } else {
+            binding.flProfile.setBackgroundResource(R.drawable.bg_g7_circle_shape_no_stroke)
+        }
+
+        binding.item = item
+        binding.stamp = getStampItemByCode(item.stampCode)
+        binding.listener = listener
+        binding.clickListener = otherUserProfileClickListener
+    }
+}


### PR DESCRIPTION
[GroupProfile]
1. ProfileAdapter와 ProfileViewHolder 간에 높은 결합도를 낮추기 위해
   inner class인 ProfileViewHodler를 외부 클래스로 분리
  -> 단일 책임 원칙 위반(ViewHolder가 Adapter 내부 로직에 관여)
2. GroupProfileFragment에서 Hilt를 사용하여 ProfileAdapter를 주입하므로 
   지정된 FragmentScope 내에서 어댑터의 생명주기가 관리되며,
   어댑터에서 Fragment의 Context를 참조하지 않으므로 WeakReference 적용이 필요 없다고 판단하였음