### PR TITLE
러닝 로그 작성 시 logId 존재 여부에 따라 저장 데이터 조회하도록 수정

### DIFF
--- a/presentation/src/main/java/com/applemango/presentation/ui/screen/fragment/mypage/runninglog/write/RunningLogFragment.kt
+++ b/presentation/src/main/java/com/applemango/presentation/ui/screen/fragment/mypage/runninglog/write/RunningLogFragment.kt
@@ -71,8 +71,10 @@ class RunningLogFragment : BaseFragment<FragmentRunningLogBinding>(R.layout.frag
         _photoManager = SinglePhotoManager(this) { croppedImage ->
             viewModel.updateLogImage(croppedImage)
         }
-        viewModel.getPostedRunningLog(navArgs.logId?.toInt() ?: 0)
-        setupPostedRunningLog()
+        navArgs.logId?.let {
+            viewModel.getPostedRunningLog(it.toInt())
+            setupPostedRunningLog()
+        }
     }
 
     override fun onDestroyView() {

--- a/presentation/src/main/res/layout/dialog_bottom_sheet_weather.xml
+++ b/presentation/src/main/res/layout/dialog_bottom_sheet_weather.xml
@@ -95,6 +95,7 @@
                 android:hint="@string/weather_temperature_hint"
                 android:includeFontPadding="false"
                 android:textSize="16sp"
+                android:textColor="@color/dark_g1"
                 android:textColorHint="@color/dark_g3_5"
                 android:inputType="numberSigned"
                 android:paddingHorizontal="12dp"

--- a/presentation/src/main/res/layout/fragment_edit_profile.xml
+++ b/presentation/src/main/res/layout/fragment_edit_profile.xml
@@ -104,7 +104,7 @@
                     android:text="@={vm.name}"
                     android:textSize="14sp"
                     android:textStyle="normal"
-                    android:textColor="@color/dark_g3_5"
+                    android:textColor="@color/dark_g1"
                     android:textColorHint="@color/dark_g3_5"
                     android:textCursorDrawable="@drawable/cursor_primary"
                     android:fontFamily="@font/pretendard_regular"

--- a/presentation/src/main/res/layout/fragment_running_address_search.xml
+++ b/presentation/src/main/res/layout/fragment_running_address_search.xml
@@ -104,7 +104,7 @@
                     android:inputType="text"
                     android:paddingStart="0dp"
                     android:paddingEnd="0dp"
-                    android:textColor="@color/dark_g3_5"
+                    android:textColor="@color/dark_g1"
                     android:textColorHint="@color/dark_g3_5" />
             </com.google.android.material.textfield.TextInputLayout>
 

--- a/presentation/src/main/res/layout/fragment_running_address_search_detail.xml
+++ b/presentation/src/main/res/layout/fragment_running_address_search_detail.xml
@@ -121,7 +121,7 @@
                 android:gravity="center_vertical"
                 android:includeFontPadding="false"
                 android:inputType="text"
-                android:textColor="@color/dark_g3_5"
+                android:textColor="@color/dark_g1"
                 android:textCursorDrawable="@drawable/cursor_primary" />
         </com.google.android.material.textfield.TextInputLayout>
 


### PR DESCRIPTION
## Feature PR Template

### 변경 전
신규 작성 상태인데도 "러닝 로그 수정 화면"처럼 기존 데이터 조회
- 원인: 신규 작성/수정 두 경로 모두에서 RunningLogFragment가 목적지이므로 NavArgs에 엘비스 연산자로 디폴트 값을 넘겨서 발생한 현상

### 변경 후
신규 작성 상태에서 "러닝 로그 상세 조회" API 호출하지 않도록 수정
- 해결: NavArgs의 logId 값 null 여부에 따라 API 호출 및 구독 여부 설정되도록 수정

### 관련 이슈
-

### 테스트 방법
주간/월간/참여한 러닝에서 "러닝 로그 신규 작성" 화면 진입

### 기타 참고 사항
EditText/TextInputEditText의 textColor가 적용되지 않은 layout 파일들에 textColor 적용
